### PR TITLE
return float64s from JSHandle

### DIFF
--- a/js_handle.go
+++ b/js_handle.go
@@ -110,7 +110,10 @@ func (j *JSHandle) JSONValue() (interface{}, error) {
 func parseValue(result interface{}) interface{} {
 	vMap := result.(map[string]interface{})
 	if v, ok := vMap["n"]; ok {
-		return int(v.(float64))
+		if math.Ceil(v.(float64))-v.(float64) == 0 {
+			return int(v.(float64))
+		}
+		return v.(float64)
 	}
 	if v, ok := vMap["s"]; ok {
 		return v.(string)

--- a/js_handle_test.go
+++ b/js_handle_test.go
@@ -99,6 +99,8 @@ func TestJSHandleTypeParsing(t *testing.T) {
 	require.NoError(t, err)
 	_, ok := intV.(int)
 	require.True(t, ok)
+	_, ok = intV.(float64)
+	require.False(t, ok)
 
 	floatHandle, err := twoHandle.(*JSHandle).GetProperty("a_float")
 	require.NoError(t, err)
@@ -106,6 +108,8 @@ func TestJSHandleTypeParsing(t *testing.T) {
 	require.NoError(t, err)
 	_, ok = floatV.(float64)
 	require.True(t, ok)
+	_, ok = floatV.(int)
+	require.False(t, ok)
 
 	stringHandle, err := twoHandle.(*JSHandle).GetProperty("a_string_of_an_integer")
 	require.NoError(t, err)
@@ -113,4 +117,6 @@ func TestJSHandleTypeParsing(t *testing.T) {
 	require.NoError(t, err)
 	_, ok = stringV.(string)
 	require.True(t, ok)
+	_, ok = stringV.(int)
+	require.False(t, ok)
 }

--- a/js_handle_test.go
+++ b/js_handle_test.go
@@ -80,3 +80,37 @@ func TestJSHandleEvaluateHandle(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, value, 2)
 }
+
+func TestJSHandleTypeParsing(t *testing.T) {
+	helper := BeforeEach(t)
+	defer helper.AfterEach()
+	aHandle, err := helper.Page.EvaluateHandle(`() => ({
+		an_integer: 1,
+		a_float: 2.2222222222,
+		a_string_of_an_integer: "3",
+	})`)
+	require.NoError(t, err)
+	twoHandle, err := aHandle.(*JSHandle).EvaluateHandle("x => x")
+	require.NoError(t, err)
+
+	integerHandle, err := twoHandle.(*JSHandle).GetProperty("an_integer")
+	require.NoError(t, err)
+	intV, err := integerHandle.JSONValue()
+	require.NoError(t, err)
+	_, ok := intV.(int)
+	require.True(t, ok)
+
+	floatHandle, err := twoHandle.(*JSHandle).GetProperty("a_float")
+	require.NoError(t, err)
+	floatV, err := floatHandle.JSONValue()
+	require.NoError(t, err)
+	_, ok = floatV.(float64)
+	require.True(t, ok)
+
+	stringHandle, err := twoHandle.(*JSHandle).GetProperty("a_string_of_an_integer")
+	require.NoError(t, err)
+	stringV, err := stringHandle.JSONValue()
+	require.NoError(t, err)
+	_, ok = stringV.(string)
+	require.True(t, ok)
+}


### PR DESCRIPTION
Without this, true floating point values are never returned and are always truncated to integers. There is very likely a more optimized way to do this. ~~Is there a reason the value can't just be returned without casting (if it's a "number")?~~ Duh: because it might be an integer and not a floating point.