### PR TITLE
Fix bug in videos example: close page

### DIFF
--- a/examples/video/main.go
+++ b/examples/video/main.go
@@ -34,6 +34,9 @@ func main() {
 	gotoPage("http://whatsmyuseragent.org")
 	gotoPage("https://github.com")
 	gotoPage("https://microsoft.com")
+	if err := page.Close(); err != nil {
+		log.Fatalf("failed to close page: %v", err)
+	}
 	fmt.Printf("Saved to %s\n", page.Video().Path())
 	if err = browser.Close(); err != nil {
 		log.Fatalf("could not close browser: %v", err)


### PR DESCRIPTION
Before this change empty video files were created. Seen on Ubuntu 20.04.1 LTS running under WSL2.