### PR TITLE
fix(ElementHandle): don't panic when QuerySelector not exists

### DIFF
--- a/element_handle.go
+++ b/element_handle.go
@@ -109,6 +109,9 @@ func (e *elementHandleImpl) QuerySelector(selector string) (ElementHandle, error
 	if err != nil {
 		return nil, err
 	}
+	if channel == nil {
+		return nil, nil
+	}
 	return fromChannel(channel).(*elementHandleImpl), nil
 }
 

--- a/tests/element_handle_test.go
+++ b/tests/element_handle_test.go
@@ -179,6 +179,22 @@ func TestElementHandleTap(t *testing.T) {
 	require.Equal(t, true, value)
 }
 
+func TestElementHandleQuerySelectorNotExists(t *testing.T) {
+	BeforeEach(t)
+	defer AfterEach(t)
+	_, err := page.Goto(server.EMPTY_PAGE)
+	require.NoError(t, err)
+	require.NoError(t, page.SetContent(`
+	<div id="a1">
+	</div>
+	`))
+	rootElement, err := page.QuerySelector("#a1")
+	require.NoError(t, err)
+	element, err := rootElement.QuerySelector(".foobar")
+	require.NoError(t, err)
+	require.Nil(t, element)
+}
+
 func TestElementHandleQuerySelectorAll(t *testing.T) {
 	BeforeEach(t)
 	defer AfterEach(t)


### PR DESCRIPTION
Fixes #110