### PR TITLE
docs: update link to Playwright API

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/mxschmitt/playwright-go)](https://goreportcard.com/report/github.com/mxschmitt/playwright-go) ![Build Status](https://github.com/mxschmitt/playwright-go/workflows/Go/badge.svg)
 [![Join Slack](https://img.shields.io/badge/join-slack-infomational)](https://aka.ms/playwright-slack) [![Coverage Status](https://coveralls.io/repos/github/mxschmitt/playwright-go/badge.svg?branch=master)](https://coveralls.io/github/mxschmitt/playwright-go?branch=master) <!-- GEN:chromium-version-badge -->[![Chromium version](https://img.shields.io/badge/chromium-90.0.4430.0-blue.svg?logo=google-chrome)](https://www.chromium.org/Home)<!-- GEN:stop --> <!-- GEN:firefox-version-badge -->[![Firefox version](https://img.shields.io/badge/firefox-87.0b10-blue.svg?logo=mozilla-firefox)](https://www.mozilla.org/en-US/firefox/new/)<!-- GEN:stop --> <!-- GEN:webkit-version-badge -->[![WebKit version](https://img.shields.io/badge/webkit-14.2-blue.svg?logo=safari)](https://webkit.org/)<!-- GEN:stop -->
 
-[API reference](https://playwright.dev/docs/api/playwright-module) | [Example recipes](https://github.com/mxschmitt/playwright-go/tree/master/examples)
+[API reference](https://playwright.dev/docs/api/class-playwright) | [Example recipes](https://github.com/mxschmitt/playwright-go/tree/master/examples)
 
 Playwright is a Go library to automate [Chromium](https://www.chromium.org/Home), [Firefox](https://www.mozilla.org/en-US/firefox/new/) and [WebKit](https://webkit.org/) with a single API. Playwright is built to enable cross-browser web automation that is **ever-green**, **capable**, **reliable** and **fast**.
 
@@ -125,5 +125,5 @@ We are ready for your feedback, but we are still covering Playwright Go with the
 ## Resources
 
 * [Playwright for Go Documentation](https://pkg.go.dev/github.com/mxschmitt/playwright-go)
-* [Playwright Documentation](https://playwright.dev/docs/api/playwright-module)
+* [Playwright Documentation](https://playwright.dev/docs/api/class-playwright)
 * [Example recipes](https://github.com/mxschmitt/playwright-go/tree/master/examples)


### PR DESCRIPTION
Slight URL change to fix a broken link to Playwright API documentation.