### PR TITLE
feat: add release-playwright skill and CLAUDE.md

### DIFF
--- a/.claude/skills/release-playwright/SKILL.md
+++ b/.claude/skills/release-playwright/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: release-playwright
+description: Cut a new GitHub release (git tag + release notes) for playwright-go. Computes the next version from the pinned driver version in run.go and the last published tag, builds release notes from merged PRs, and publishes the release. Use when asked to "release", "cut a release", "tag a release", "publish a new version", or right after a roll-playwright PR has merged to main.
+---
+
+# Release playwright-go
+
+Publish a new tagged GitHub release of `mxschmitt/playwright-go`. This is usually the last step right after a [`roll-playwright`](../roll-playwright/SKILL.md) PR merges to `main`, but can also be run standalone to ship accumulated non-roll fixes.
+
+## Versioning scheme
+
+Releases are **not** semver-on-the-package; the tag encodes the upstream Playwright driver version: `v0.<MM><PP>.<G>`
+
+- `MM` — upstream minor version, two digits (`1.62.x` → `62`).
+- `PP` — upstream driver's own patch digit, two digits (`1.62.1` → `01`). This is **not** an independent counter — it is meant to literally equal the driver's patch number.
+- `G` — a go-package-only patch counter. Starts at `0` for a new `MM`+`PP` combination; increments only when a release ships with **no driver version change** (e.g. a bugfix-only release), reusing the same `MM`+`PP`.
+
+Examples from history: driver `1.51.1` → `v0.5101.0`; driver `1.52.0` → `v0.5200.0`, then a go-only fix on the same driver → `v0.5200.1`.
+
+> **Known exception:** `v0.6100.0` was published for driver `1.61.1` but used `PP=00` instead of the expected `01` — a one-off inconsistency (coincided with the org migration to `mxschmitt`), not a scheme change. Don't treat it as precedent; if you find another tag that breaks the `PP == driver patch` rule, flag it to the user rather than silently following it.
+
+## Step 1 — Compute the candidate version
+
+```bash
+bash .claude/skills/release-playwright/compute-version.sh
+```
+
+Prints the pinned driver version (`run.go`), the latest published release, the candidate next tag, and a sanity-check table of the last several releases' tags against the driver version each actually pinned. Read that table — if any entry (besides the known `v0.6100.0` exception above) breaks the `PP == driver patch` rule, the scheme has drifted further and you should ask the user how to proceed instead of guessing.
+
+## Step 2 — Confirm the release point
+
+1. `git fetch origin main && git status` — confirm your local `main` matches `origin/main` (fast-forward only, no divergence). If a `roll-playwright` PR just merged, that merge commit is normally the release point.
+2. Confirm CI is green on `main` at that commit before tagging:
+   ```bash
+   RUN=$(gh run list --repo mxschmitt/playwright-go --branch main --limit 1 --json databaseId,headSha --jq '.[0]')
+   echo "$RUN"   # confirm headSha matches `git rev-parse HEAD`, then:
+   gh run view "$(jq -r .databaseId <<<"$RUN")" --repo mxschmitt/playwright-go --exit-status
+   ```
+   Do not release on a red or stale run.
+
+## Step 3 — Write release notes
+
+Two cases:
+
+- **After a roll** (the common case): pull the "New APIs" / "Behavior changes" / "Fixes" sections straight from the merged roll PR body (`gh pr view <num> --repo mxschmitt/playwright-go --json body --jq .body`) and reshape into the established header format (see any past release for the shape, e.g. `gh release view v0.6201.0 --repo mxschmitt/playwright-go`). Pull browser versions from the README's `GEN:` markers:
+  ```bash
+  grep -oE '(chromium|firefox|webkit)-version -->[^<]+' README.md
+  ```
+  Include the `[!IMPORTANT]` reinstall callout with the new tag baked into the example command:
+  ```
+  go run github.com/mxschmitt/playwright-go/cmd/playwright@v<NEW_TAG> install --with-deps
+  ```
+- **Non-roll release** (accumulated fixes only): a short summary paragraph is enough; skip the driver-version/reinstall callout since the driver didn't change.
+
+Write the custom header to a file. **Do not include a `## What's Changed` heading in it** — `--generate-notes` (Step 4) appends its own, and including one yourself produces a duplicate (a real mistake made the first time this skill's process was done by hand — the release had to be edited after publishing to fix it).
+
+## Step 4 — Tag and publish
+
+```bash
+gh release create v<NEW_TAG> --repo mxschmitt/playwright-go --target main \
+  --title "v<NEW_TAG>" \
+  --notes-file <your-header-file> \
+  --generate-notes \
+  --latest
+```
+
+`--generate-notes` appends the auto-generated "What's Changed" PR list (and "New Contributors" if applicable) after your custom header, computed against the previous tag automatically. Omit `--latest` if this is a patch to an older line rather than the newest release.
+
+## Step 5 — Verify
+
+```bash
+gh release view v<NEW_TAG> --repo mxschmitt/playwright-go
+```
+
+Confirm: no duplicate headings, the tag points at the intended commit (`git rev-parse v<NEW_TAG>` should equal the `main` HEAD from Step 2), it's marked `Latest` if intended, and the PR list in "What's Changed" matches what actually merged since the last tag.
+
+## When to ask the user
+
+- The version-number scheme doesn't cleanly resolve (Step 1's sanity check flags a second inconsistent tag, or the driver version in `run.go` doesn't obviously map to `MM.PP`).
+- It's unclear whether a release should be cut now vs. batching further changes first.
+- Whether to mark the release `--latest` (e.g. driver is a pre-release/beta version, or this is a patch to a non-latest line).
+- CI on `main` isn't green at the intended release commit.
+
+Otherwise this is a short, mechanical flow — work it autonomously once the version is confirmed.
+
+## Files
+
+- `compute-version.sh` — read-only helper for Step 1.

--- a/.claude/skills/release-playwright/compute-version.sh
+++ b/.claude/skills/release-playwright/compute-version.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 
 REPO="mxschmitt/playwright-go"
 
-driver_version=$(grep -oE 'playwrightCliVersion[[:space:]]*=[[:space:]]*"[0-9.]+"' run.go | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+driver_version=$(grep -oE 'playwrightCliVersion[[:space:]]*=[[:space:]]*"[0-9.]+"' run.go | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || true)
 if [[ -z "$driver_version" ]]; then
   echo "Could not find playwrightCliVersion in run.go" >&2
   exit 1

--- a/.claude/skills/release-playwright/compute-version.sh
+++ b/.claude/skills/release-playwright/compute-version.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Read-only helper for release-playwright: prints the pinned driver version,
+# the latest published release, and the candidate next tag.
+#
+# Usage: bash .claude/skills/release-playwright/compute-version.sh
+set -euo pipefail
+
+REPO="mxschmitt/playwright-go"
+
+driver_version=$(grep -oE 'playwrightCliVersion[[:space:]]*=[[:space:]]*"[0-9.]+"' run.go | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+if [[ -z "$driver_version" ]]; then
+  echo "Could not find playwrightCliVersion in run.go" >&2
+  exit 1
+fi
+
+minor=$(cut -d. -f2 <<<"$driver_version")
+patch=$(cut -d. -f3 <<<"$driver_version")
+mm=$(printf "%02d" "$minor")
+pp=$(printf "%02d" "$patch")
+base="v0.${mm}${pp}"
+
+latest_tag=$(gh release list --repo "$REPO" --limit 1 --json tagName --jq '.[0].tagName')
+
+echo "Pinned driver version (run.go): $driver_version"
+echo "Latest published release:       ${latest_tag:-<none found>}"
+echo
+
+if [[ "$latest_tag" == "${base}."* ]]; then
+  last_g=$(cut -d. -f3 <<<"$latest_tag")
+  next_g=$((last_g + 1))
+  echo "Same driver version as the latest release -> this looks like a go-only patch release (no driver bump)."
+  echo "Candidate tag: ${base}.${next_g}"
+else
+  echo "Driver version differs from the latest release's -> this looks like a new roll release."
+  echo "Candidate tag (mm=minor, pp=driver patch, following the v0.<mm><pp>.0 convention): ${base}.0"
+fi
+
+echo
+echo "--- Sanity check against history (does the mm+pp digit pattern actually track the driver patch?) ---"
+gh release list --repo "$REPO" --limit 8 --json tagName --jq '.[].tagName' | while read -r tag; do
+  dv=$(git show "${tag}:run.go" 2>/dev/null | grep -oE 'playwrightCliVersion[[:space:]]*=[[:space:]]*"[0-9.]+"' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || true)
+  echo "$tag -> driver $dv"
+done
+echo
+echo "NOTE: v0.6100.0 is a known one-off exception (pinned driver 1.61.1 but used '00' not '01')."
+echo "Do not treat it as the new pattern without asking the user first — see SKILL.md 'When to ask the user'."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,11 @@
+# CLAUDE.md
+
+Project-specific instructions for Claude Code working in this repo.
+
+## Rolling to a new Playwright version
+
+Always use the [`roll-playwright`](.claude/skills/roll-playwright/SKILL.md) skill for this — do not bump `playwrightCliVersion` or edit `patches/main.patch` by hand outside of it. It encodes the submodule/patch/codegen workflow and the cross-binding parity checks against python/java/dotnet.
+
+## Cutting a release
+
+Always use the [`release-playwright`](.claude/skills/release-playwright/SKILL.md) skill for this — do not hand-tag a release. It encodes the version-numbering convention (`v0.<MM><PP>.<G>`, tracking the upstream driver's own minor+patch) and the release-notes format; guessing the version number by hand has produced at least one inconsistent tag (`v0.6100.0`) in the past.


### PR DESCRIPTION
Cutting v0.6201.0 by hand today required reverse-engineering the version-numbering convention from 19 past release tags, and turned up an undocumented inconsistency (`v0.6100.0` was published for driver `1.61.1` but used `00` instead of the expected `01`). Nothing wrote that convention down, so every release depends on someone reconstructing it.

This adds a `release-playwright` skill (mirroring `roll-playwright`) that:
- computes the next version from the driver version pinned in `run.go` and the last published tag, via a read-only `compute-version.sh` helper,
- sanity-checks recent tags against their own pinned driver version so a second scheme drift gets flagged instead of silently followed,
- documents the release-notes format (and a gotcha hit while doing this by hand: combining a custom `--notes-file` with `--generate-notes` produces a duplicate `## What's Changed` heading unless the custom notes omit their own),
- and lists explicit "ask the user" triggers (ambiguous version, unclear whether to release now, `--latest` flag, non-green CI on `main`).

Also adds `CLAUDE.md` pointing both `roll-playwright` and `release-playwright` out as the required entry points for those two workflows, so a session doesn't bump the version or tag a release by hand outside the skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
