### PR TITLE
test: stop TestShouldUploadAFolderRemote from eating the package timeout

### DIFF
--- a/tests/browser_type_test.go
+++ b/tests/browser_type_test.go
@@ -580,74 +580,75 @@ func TestSetInputFilesShouldPreserveLastModifiedTimestamp(t *testing.T) {
 	}
 }
 
+// TestShouldUploadAFolderRemote occasionally wedges on the browser side under
+// WebKit on GitHub's hosted macOS runners: SetInputFiles never returns. Upstream
+// sees the same and marks the equivalent test test.slow() while leaning on its
+// `retries: 3`. Observed durations here are bimodal — ~1s when it works, "never"
+// when it wedges — so inflating the action timeout only makes a wedged run more
+// expensive, it does not buy success. Deliberately keep the default 30s action
+// timeout and no in-test retry loop: gotestsum's --rerun-fails in
+// .github/workflows/build.yml supplies the retries, in a fresh process with its
+// own -timeout budget, and reports the flake to flakiness.io.
 func TestShouldUploadAFolderRemote(t *testing.T) {
-	// WebKit folder upload over a remote connection (file streaming + browser
-	// ingestion) is genuinely slow on loaded CI runners and is flaky upstream
-	// too: microsoft/playwright marks the equivalent test test.slow() (a 90s
-	// budget) and still has to lean on its CI retries: 3 to stay green (we have
-	// observed it reported as "1 flaky" on their webkit job). Our CI does not
-	// retry, so mirror upstream by retrying the whole test a few times; each
-	// attempt also gets a generous 180s action timeout for headroom.
-	withRetry(t, 3, func(t testing.TB) {
-		remoteServer, err := newRemoteServer()
-		require.NoError(t, err)
-		defer remoteServer.Close()
+	BeforeEach(t)
 
-		browser1, err := browserType.Connect(remoteServer.url)
-		require.NoError(t, err)
-		require.NotNil(t, browser1)
-		defer browser1.Close() //nolint:errcheck
+	remoteServer, err := newRemoteServer()
+	require.NoError(t, err)
+	defer remoteServer.Close()
 
-		browser_context, err := browser1.NewContext()
-		require.NoError(t, err)
-		page, err := browser_context.NewPage()
-		require.NoError(t, err)
-		page.SetDefaultTimeout(180 * 1000)
+	browser1, err := browserType.Connect(remoteServer.url)
+	require.NoError(t, err)
+	require.NotNil(t, browser1)
+	defer browser1.Close() //nolint:errcheck
 
-		_, err = page.Goto(fmt.Sprintf("%s%s", server.PREFIX, "/input/folderupload.html"))
-		require.NoError(t, err)
+	browser_context, err := browser1.NewContext()
+	require.NoError(t, err)
+	page, err := browser_context.NewPage()
+	require.NoError(t, err)
 
-		//nolint:staticcheck
-		input, err := page.QuerySelector("input")
-		require.NoError(t, err)
+	_, err = page.Goto(fmt.Sprintf("%s%s", server.PREFIX, "/input/folderupload.html"))
+	require.NoError(t, err)
 
-		dir := filepath.Join(t.TempDir(), "file-upload-test")
-		require.NoError(t, os.MkdirAll(dir, 0o700))
-		require.NoError(t, os.WriteFile(filepath.Join(dir, "file1.txt"), []byte("file1 content"), 0o600))
-		require.NoError(t, os.WriteFile(filepath.Join(dir, "file2"), []byte("file2 content"), 0o600))
-		require.Nil(t, os.Mkdir(filepath.Join(dir, "sub-dir"), 0o700))
-		require.NoError(t, os.WriteFile(filepath.Join(dir, "sub-dir", "really.txt"), []byte("sub-dir file content"), 0o600))
-		//nolint:staticcheck
-		require.NoError(t, input.SetInputFiles(dir))
+	//nolint:staticcheck
+	input, err := page.QuerySelector("input")
+	require.NoError(t, err)
 
-		ret, err := input.Evaluate(`e => [...e.files].map(f => f.webkitRelativePath)`)
-		require.NoError(t, err)
+	dir := filepath.Join(t.TempDir(), "file-upload-test")
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "file1.txt"), []byte("file1 content"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "file2"), []byte("file2 content"), 0o600))
+	require.Nil(t, os.Mkdir(filepath.Join(dir, "sub-dir"), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "sub-dir", "really.txt"), []byte("sub-dir file content"), 0o600))
+	//nolint:staticcheck
+	require.NoError(t, input.SetInputFiles(dir))
 
-		expectResult := []interface{}{"file-upload-test/file1.txt", "file-upload-test/file2"}
-		// https://issues.chromium.org/issues/345393164
-		if !isChromium || !headless || !chromiumVersionLessThan(browser.Version(), "127.0.6533.0") {
-			expectResult = append(expectResult, "file-upload-test/sub-dir/really.txt")
-		}
-		slices.SortFunc(ret.([]interface{}), func(i, j interface{}) int {
-			return strings.Compare(i.(string), j.(string))
-		})
-		require.Equal(t, expectResult, ret.([]interface{}))
+	ret, err := input.Evaluate(`e => [...e.files].map(f => f.webkitRelativePath)`)
+	require.NoError(t, err)
 
-		webkitRelativePaths, err := input.Evaluate(`e => [...e.files].map(f => f.webkitRelativePath)`)
-		require.NoError(t, err)
-		for i, path := range webkitRelativePaths.([]interface{}) {
-			content, err := input.Evaluate(`(e, i) => {
+	expectResult := []interface{}{"file-upload-test/file1.txt", "file-upload-test/file2"}
+	// https://issues.chromium.org/issues/345393164
+	if !isChromium || !headless || !chromiumVersionLessThan(browser.Version(), "127.0.6533.0") {
+		expectResult = append(expectResult, "file-upload-test/sub-dir/really.txt")
+	}
+	slices.SortFunc(ret.([]interface{}), func(i, j interface{}) int {
+		return strings.Compare(i.(string), j.(string))
+	})
+	require.Equal(t, expectResult, ret.([]interface{}))
+
+	webkitRelativePaths, err := input.Evaluate(`e => [...e.files].map(f => f.webkitRelativePath)`)
+	require.NoError(t, err)
+	for i, path := range webkitRelativePaths.([]interface{}) {
+		content, err := input.Evaluate(`(e, i) => {
 			const reader = new FileReader();
 			const promise = new Promise(fulfill => reader.onload = fulfill);
 			reader.readAsText(e.files[i]);
 			return promise.then(() => reader.result);
     }`, i)
-			require.NoError(t, err)
-			b, err := os.ReadFile(filepath.Join(dir, "..", path.(string)))
-			require.NoError(t, err)
-			require.Equal(t, string(b), content.(string))
-		}
-	})
+		require.NoError(t, err)
+		b, err := os.ReadFile(filepath.Join(dir, "..", path.(string)))
+		require.NoError(t, err)
+		require.Equal(t, string(b), content.(string))
+	}
 }
 
 func TestBrowserBind(t *testing.T) {

--- a/tests/helper_test.go
+++ b/tests/helper_test.go
@@ -54,56 +54,6 @@ func skipWebKitMacOSPopup(t *testing.T) {
 	}
 }
 
-// attemptT wraps *testing.T but captures assertion failures locally instead of
-// propagating them to the real test. It satisfies testify's require.TestingT
-// and the parts of testing.TB our tests use, so an existing test body can run
-// against it unchanged.
-type attemptT struct {
-	*testing.T
-	failed bool
-}
-
-func (a *attemptT) Errorf(format string, args ...interface{}) {
-	a.failed = true
-	a.Logf("[retry] "+format, args...)
-}
-
-func (a *attemptT) FailNow() {
-	a.failed = true
-	runtime.Goexit()
-}
-
-// withRetry runs body up to attempts times and passes as soon as one attempt
-// succeeds, failing the test only if every attempt fails. Each attempt runs in
-// its own goroutine so a require.* failure (which calls runtime.Goexit) ends
-// only that attempt, and gets a fresh browser context/page via BeforeEach so a
-// botched attempt never leaks state into the next one.
-//
-// Use this only for tests that are genuinely correct but occasionally too slow
-// on loaded CI runners (where upstream relies on its CI retries: 3) — not to
-// paper over real bugs. The body receives a testing.TB; pass it to require.*
-// and use it wherever the test would otherwise use t.
-func withRetry(t *testing.T, attempts int, body func(t testing.TB)) {
-	t.Helper()
-	for i := 0; i < attempts; i++ {
-		a := &attemptT{T: t}
-		done := make(chan struct{})
-		go func() {
-			defer close(done)
-			BeforeEach(a.T)
-			body(a)
-		}()
-		<-done
-		if !a.failed {
-			return
-		}
-		if i < attempts-1 {
-			t.Logf("attempt %d/%d failed, retrying", i+1, attempts)
-		}
-	}
-	t.Fatalf("still failing after %d attempts", attempts)
-}
-
 // BeforeAll prepares the environment, including
 //   - start Playwright driver
 //   - launch browser depends on BROWSER env


### PR DESCRIPTION
Fixes the `webkit on macos-latest, go stable` failure in [run 31647267347](https://github.com/mxschmitt/playwright-go/actions/runs/31647267347/job/94283635628) on `main`.

## Postmortem

### Impact

`main` was red for ~4 days. One matrix leg (`webkit` / `macos-latest` / `go stable`) failed with `Process completed with exit code 3`; the other 19 legs passed. No user-facing bug — this was a CI-only failure.

### What the job did

```
panic: test timed out after 15m0s
	running tests:
		TestResponseServerAddrReturnNilForFulfilledRoute (0s)
...
FAIL	github.com/mxschmitt/playwright-go/tests	902.944s
ERROR rerun aborted because previous run had a suspected panic and some test may not have run
DONE 724 tests, 23 skipped, 2 failures in 903.398s
```

The named test is a red herring — it had been running for 0s. The whole `tests` package blew its `-timeout=15m` budget.

### Root cause

`TestShouldUploadAFolderRemote` took **366.99s** and still reported `PASS`. In the sibling `go oldstable` job, same commit, same OS, the same test took **1.37s**.

The 367s decomposes exactly:

```
helper_test.go:68: [retry] playwright: timeout: Timeout 180000ms exceeded.   (browser_type_test.go:621, input.SetInputFiles)
browser_type_test.go:591: attempt 1/3 failed, retrying
helper_test.go:68: [retry] playwright: timeout: Timeout 180000ms exceeded.
browser_type_test.go:591: attempt 2/3 failed, retrying
--- PASS: TestShouldUploadAFolderRemote (366.99s)                            180 + 180 + ~7
```

Timeline confirms it: every test after the upload test is shifted by ~6m58s versus the passing job.

| | passing job (`go oldstable`) | failing job (`go stable`) |
|---|---|---|
| `TestSetInputFilesShouldPreserveLastModifiedTimestamp` PASS | 22:32:09 | 22:33:01 |
| `TestShouldUploadAFolderRemote` PASS | 22:32:10 (1.37s) | 22:39:08 (366.99s) |
| `TestBrowserBind` PASS | 22:32:11 | 22:39:10 |
| package total | `ok … 488.187s` | `FAIL … 902.944s` (budget: 900s) |

So: a ~490s suite plus ~366s of wasted retry equals ~855s of test work, and normal runner variance carried it over the 900s line.

### Why the mitigation was the problem

The WebKit folder-upload wedge is a known, upstream-visible flake — `microsoft/playwright` marks the equivalent test `test.slow()` and relies on `retries: 3`. Two changes stacked on top of each other here:

- **#616** added an in-test retry loop (`withRetry(t, 3, …)`) with a 180s action timeout, because *"our CI does not retry"*.
- **#621** then added `gotestsum --rerun-fails=2` — so from that point on, CI **did** retry.

That left two retry layers, and the in-test one is strictly the worse of the two:

|  | in-test `withRetry` | gotestsum `--rerun-fails` |
|---|---|---|
| where the retry runs | same `go test` process | fresh process, fresh `-timeout` budget |
| cost charged to the package budget | up to 3 × 180s = 540s | ~0 |
| flake visible on flakiness.io | no — test reports `PASS` | yes — failed attempt is uploaded |

The blast radius was larger than one test. Once the package panicked on timeout, gotestsum printed `rerun aborted because previous run had a suspected panic` — so the retry safety net was disabled for **all 724 tests** in the job, not just this one.

Secondary contributor: the 180s timeout was chosen as *"generous headroom"* on the theory that the upload is "genuinely slow on loaded CI runners." The data says otherwise. Durations are bimodal — ~1s when it works, and effectively "never" when the browser wedges. In the failing run, attempts 1 and 2 hit 180s and attempt 3 finished in ~7s. A larger timeout buys no additional success probability; it only makes a wedge more expensive.

### Reproduction

Not reproducible locally on macOS/arm64 (M-series, 12 cores), which is consistent with it being a browser-side wedge specific to GitHub's hosted macOS runners:

- WebKit, 10× serial: all pass, 0.69–1.26s
- WebKit, 12× serial with `--race` under 22 saturating CPU hogs (load avg ~48): all pass, 0.94–2.28s
- chromium 2×: 0.39s / 0.42s · firefox 2×: 1.51s / 1.16s

The *failure* mechanism, by contrast, is fully determined from the logs and arithmetic above.

### Fix

Delete the in-test retry layer and the inflated action timeout; let gotestsum own retries.

- `TestShouldUploadAFolderRemote` runs straight-line again with the default 30s action timeout.
- A wedge now costs 30s instead of 540s, cannot push the package past `-timeout`, and cannot take down the rerun safety net for the rest of the suite.
- A wedge is reported as a real failed attempt, so it shows up as flaky on flakiness.io instead of being silently swallowed — which is exactly the design #621 documented in `build.yml`.
- `withRetry` / `attemptT` had no other callers and are removed (they would otherwise trip `unused`). The comment on the test now records *why* there is deliberately no retry here, so it does not get re-added.

### Residual risk

The `webkit`/`macos` suite currently uses ~490s of the 900s `-timeout` budget. That is comfortable today, but the guard is package-wide: any single test that can wedge for minutes threatens the whole job, and a resulting timeout panic disables gotestsum's reruns for everything. Worth remembering the next time a "just give it a bigger timeout" mitigation is proposed — bounded timeout plus CI-level retry is the pattern that holds.

## Verification

- `gofmt`, `go vet ./...`, `golangci-lint run ./...` (v2) — clean
- `TestShouldUploadAFolderRemote` + `TestSetInputFilesShouldPreserveLastModifiedTimestamp`, webkit, `-count=3 --race` — pass
- chromium and firefox, `-count=2 --race` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbHRZ366YgsmofGFq21Kxy
