### PR TITLE
fix: accept Request/Response predicates in Page.ExpectRequest/ExpectResponse

### DIFF
--- a/page.go
+++ b/page.go
@@ -608,7 +608,7 @@ func (p *pageImpl) waiterForEvent(event string, options ...PageWaitForEventOptio
 	return waiter.WaitForEvent(p, event, predicate)
 }
 
-func (p *pageImpl) waiterForRequest(url any, options ...PageExpectRequestOptions) *waiter {
+func (p *pageImpl) waiterForRequest(urlOrPredicate any, options ...PageExpectRequestOptions) *waiter {
 	option := PageExpectRequestOptions{}
 	if len(options) == 1 {
 		option = options[0]
@@ -617,10 +617,18 @@ func (p *pageImpl) waiterForRequest(url any, options ...PageExpectRequestOptions
 		option.Timeout = Float(p.timeoutSettings.Timeout())
 	}
 	var matcher *urlMatcher
-	if url != nil {
-		matcher = newURLMatcher(url, p.browserContext.options.BaseURL)
+	var matchRequest func(Request) bool
+	switch v := urlOrPredicate.(type) {
+	case nil:
+	case func(Request) bool:
+		matchRequest = v
+	default:
+		matcher = newURLMatcher(urlOrPredicate, p.browserContext.options.BaseURL)
 	}
 	predicate := func(req *requestImpl) bool {
+		if matchRequest != nil {
+			return matchRequest(req)
+		}
 		if matcher != nil {
 			return matcher.Matches(req.URL())
 		}
@@ -634,7 +642,7 @@ func (p *pageImpl) waiterForRequest(url any, options ...PageExpectRequestOptions
 	return waiter.WaitForEvent(p, "request", predicate)
 }
 
-func (p *pageImpl) waiterForResponse(url any, options ...PageExpectResponseOptions) *waiter {
+func (p *pageImpl) waiterForResponse(urlOrPredicate any, options ...PageExpectResponseOptions) *waiter {
 	option := PageExpectResponseOptions{}
 	if len(options) == 1 {
 		option = options[0]
@@ -643,12 +651,20 @@ func (p *pageImpl) waiterForResponse(url any, options ...PageExpectResponseOptio
 		option.Timeout = Float(p.timeoutSettings.Timeout())
 	}
 	var matcher *urlMatcher
-	if url != nil {
-		matcher = newURLMatcher(url, p.browserContext.options.BaseURL)
+	var matchResponse func(Response) bool
+	switch v := urlOrPredicate.(type) {
+	case nil:
+	case func(Response) bool:
+		matchResponse = v
+	default:
+		matcher = newURLMatcher(urlOrPredicate, p.browserContext.options.BaseURL)
 	}
-	predicate := func(req *responseImpl) bool {
+	predicate := func(res *responseImpl) bool {
+		if matchResponse != nil {
+			return matchResponse(res)
+		}
 		if matcher != nil {
-			return matcher.Matches(req.URL())
+			return matcher.Matches(res.URL())
 		}
 		return true
 	}
@@ -726,16 +742,16 @@ func (p *pageImpl) ExpectPopup(cb func() error, options ...PageExpectPopupOption
 	return ret.(*pageImpl), err
 }
 
-func (p *pageImpl) ExpectResponse(url any, cb func() error, options ...PageExpectResponseOptions) (Response, error) {
-	ret, err := p.waiterForResponse(url, options...).RunAndWait(cb)
+func (p *pageImpl) ExpectResponse(urlOrPredicate any, cb func() error, options ...PageExpectResponseOptions) (Response, error) {
+	ret, err := p.waiterForResponse(urlOrPredicate, options...).RunAndWait(cb)
 	if ret == nil {
 		return nil, err
 	}
 	return ret.(*responseImpl), err
 }
 
-func (p *pageImpl) ExpectRequest(url any, cb func() error, options ...PageExpectRequestOptions) (Request, error) {
-	ret, err := p.waiterForRequest(url, options...).RunAndWait(cb)
+func (p *pageImpl) ExpectRequest(urlOrPredicate any, cb func() error, options ...PageExpectRequestOptions) (Request, error) {
+	ret, err := p.waiterForRequest(urlOrPredicate, options...).RunAndWait(cb)
 	if ret == nil {
 		return nil, err
 	}

--- a/tests/page_test.go
+++ b/tests/page_test.go
@@ -344,6 +344,21 @@ func TestPageExpectRequestFunc(t *testing.T) {
 	require.Equal(t, "GET", request.Method())
 }
 
+func TestPageExpectRequestPredicate(t *testing.T) {
+	BeforeEach(t)
+
+	request, err := page.ExpectRequest(func(r playwright.Request) bool {
+		return r.Method() == "GET" && strings.HasSuffix(r.URL(), "empty.html")
+	}, func() error {
+		_, err := page.Goto(server.EMPTY_PAGE)
+		return err
+	})
+	require.NoError(t, err)
+	require.Equal(t, server.EMPTY_PAGE, request.URL())
+	require.Equal(t, "document", request.ResourceType())
+	require.Equal(t, "GET", request.Method())
+}
+
 func TestPageExpectRequestFinished(t *testing.T) {
 	BeforeEach(t)
 
@@ -1139,6 +1154,19 @@ func TestPageExpectResponse(t *testing.T) {
 
 		predicate := regexp.MustCompile(`(?i).*/one-style.html`)
 		response, err := page.ExpectResponse(predicate, func() error {
+			_, err := page.Goto(server.PREFIX + "/one-style.html")
+			return err
+		}, playwright.PageExpectResponseOptions{Timeout: playwright.Float(3 * 1000)})
+		require.NoError(t, err)
+		require.Equal(t, fmt.Sprintf("%s/one-style.html", server.PREFIX), response.URL())
+	})
+
+	t.Run("should work with response predicate", func(t *testing.T) {
+		BeforeEach(t)
+
+		response, err := page.ExpectResponse(func(r playwright.Response) bool {
+			return r.Status() == 200 && strings.HasSuffix(r.URL(), "one-style.html")
+		}, func() error {
 			_, err := page.Goto(server.PREFIX + "/one-style.html")
 			return err
 		}, playwright.PageExpectResponseOptions{Timeout: playwright.Float(3 * 1000)})


### PR DESCRIPTION
Fixes #627

## Problem

`Page.ExpectRequest` / `Page.ExpectResponse` document `urlOrPredicate` as *"Request URL string, regex or predicate receiving [Request]/[Response] object"*, but both handed the argument straight to `newURLMatcher`, which only understands `string`, `*regexp.Regexp` and `func(string) bool`. Anything else hits the `panic(fmt.Errorf("invalid urlOrPredicate: %v", ...))` at the bottom of that function.

Reproducer (panics on `main`):

```go
request, err := page.ExpectRequest(func(r playwright.Request) bool {
    return r.Method() == "GET" && strings.HasSuffix(r.URL(), "empty.html")
}, func() error {
    _, err := page.Goto(server.EMPTY_PAGE)
    return err
})
```

```
panic: invalid urlOrPredicate: 0x1031e73f0
    playwright-go.newURLMatcher(...)  helpers.go:208
    playwright-go.(*pageImpl).waiterForRequest(...)  page.go:621
```

So there was no way to filter on anything but the URL — `Method()`, `PostData()`, `Status()`, `Headers()` were all out of reach, even though every sibling binding supports it.

## Fix

Match the object predicate in `waiterForRequest` / `waiterForResponse` before falling back to the URL matcher:

```go
var matcher *urlMatcher
var matchRequest func(Request) bool
switch v := urlOrPredicate.(type) {
case nil:
case func(Request) bool:
    matchRequest = v
default:
    matcher = newURLMatcher(urlOrPredicate, p.browserContext.options.BaseURL)
}
```

The existing `string` / `*regexp.Regexp` / `func(string) bool` forms are untouched, so this is purely additive — no behavior change for any input that worked before.

Also renamed the `url` parameter to `urlOrPredicate` in these four methods to match the interface declaration (noted in the issue).

## Tests

- `TestPageExpectRequestPredicate` — `func(playwright.Request) bool` filtering on `Method()` + URL
- `TestPageExpectResponse/should_work_with_response_predicate` — `func(playwright.Response) bool` filtering on `Status()` + URL

Both panic before the change and pass after. Existing `TestPage*`, `TestNetwork*`, `TestRoute*` and `TestBrowserContext*` suites still pass.

## How this regressed

Short version: the capability existed in 2020, was dropped as collateral damage when the variadic `options` parameter got a concrete type, and stayed invisible for two years because the docs are generated from upstream while the matching logic is hand-written.

**2020-08-28 — [#19](https://github.com/mxschmitt/playwright-go/pull/19) `feat: expect wrappers`.** The original `WaitForRequest` *did* support an object predicate, but through the second parameter rather than the first:

```go
func (p *Page) WaitForRequest(url interface{}, options ...interface{}) *Request {
    var matcher *urlMatcher
    if url != nil {
        matcher = newURLMatcher(url)
    }
    predicate := func(req *Request) bool {
        if matcher != nil {
            return matcher.Match(req.URL())
        }
        if len(options) == 1 {
            return reflect.ValueOf(options[0]).Call([]reflect.Value{reflect.ValueOf(req)})[0].Bool()
        }
        return true
    }
```

Note the shape: `urlOrPredicate` was URL-only from day one, and the object predicate rode in on untyped `options...`. That split is the root of everything below.

**2023-06-19 — [#352](https://github.com/mxschmitt/playwright-go/pull/352) `chore: roll to Playwright v1.30.0`.** `options ...interface{}` became `options ...PageWaitForRequestOptions`. The reflect branch could no longer compile against a typed struct, so it was deleted. Nothing took its place, and `urlOrPredicate` was never widened to absorb the capability. The object-predicate feature left the library here, inside a large roll PR, as a side effect of a type change rather than a decision anyone made.

**2024-01-24 — [#407](https://github.com/mxschmitt/playwright-go/pull/407) `feat: roll to Playwright v1.41.1`.** `newURLMatcher` gained `func(string) bool` and the trailing `panic` for unrecognized types. Two consequences: the gap became a hard panic instead of a silent non-match, and — worse for discoverability — a *function* type was now accepted, so `ExpectRequest` looked like it supported predicates. It just supported the wrong one.

**2026-08 — [#627](https://github.com/mxschmitt/playwright-go/issues/627).** Reported by a user, from the doc comment.

### Why nothing caught it

1. **Docs and implementation have different sources.** The doc comment on `ExpectRequest` is generated from upstream's API description, which describes the JS signature where the predicate receives a `Request`. The matching logic is hand-written. Nothing checks that the hand-written side actually implements what the generated comment promises, so the two drifted silently and the docs stayed correct-looking for over two years.
2. **`func(string) bool` masks the hole.** `TestPageExpectRequestFunc` covers predicate filtering — with a `func(string) bool`. Coverage looked complete. Test names like "Func" / "with predicate" read as "predicates are handled" without saying *which* predicate.
3. **Removal happened inside a roll PR.** #352 was a version roll touching many files; deleting four lines of reflect to satisfy the compiler is exactly the kind of edit that reads as mechanical cleanup during review.
4. **`any` defers the error to runtime.** `urlOrPredicate any` means a wrong predicate type is a panic on a live browser, not a compile error. There is no way for the compiler to tell a user the set of accepted types, and no way for it to tell a maintainer that one of the documented types is unhandled.

### Follow-ups worth considering

- **Audit the other generated/hand-written matcher boundaries.** `grep -n "predicate receiving" generated-interfaces.go` returns six hits; the other four (`Route`, `WaitForURL`, `ExpectNavigation` × 2) say "predicate receiving [URL]", which maps correctly to `func(string) bool`. Those are fine today — but the same drift can happen again on the next roll, and only a manual grep would notice.
- **Return an error instead of `panic` for unhandled types.** A panic from a library on a bad argument type is harsh, and here it panicked on an argument the docs told the user to pass. Out of scope for this PR since `newURLMatcher` is on several non-error-returning paths (`Route`, `Unroute`, `RouteWebSocket`), but worth a separate change.
- **Name predicate tests by the type they exercise.** `TestPageExpectRequestFunc` → the new test is `TestPageExpectRequestPredicate`; ideally both names say `URLPredicate` / `RequestPredicate` so a coverage gap of this shape is visible from the test list alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hr35MBUfsUG9DnxhBgBcZW
