### PR TITLE
fix: accept mixed string/regexp lists in ToHaveText, ToContainText, ToHaveClass

### DIFF
--- a/assertions.go
+++ b/assertions.go
@@ -152,6 +152,19 @@ func toExpectedTextValues(
 	return out, nil
 }
 
+// isExpectedList reports whether the expected value is a list rather than a
+// single item. It mirrors upstream's `Array.isArray(expected)` branch: the
+// element types do not select the branch, they are validated per item by
+// toExpectedTextValues. This is what makes a mixed list such as
+// []any{"foo", regexp.MustCompile("bar")} work, matching the documented
+// "string or RegExp or a list of those" (upstream Array<string|RegExp>).
+func isExpectedList(expected any) bool {
+	if expected == nil {
+		return false
+	}
+	return reflect.ValueOf(expected).Kind() == reflect.Slice
+}
+
 func convertToInterfaceList(v any) []any {
 	rv := reflect.ValueOf(v)
 	if rv.Kind() != reflect.Slice {

--- a/locator_assertions.go
+++ b/locator_assertions.go
@@ -2,7 +2,6 @@ package playwright
 
 import (
 	"fmt"
-	"regexp"
 )
 
 type locatorAssertionsImpl struct {
@@ -249,8 +248,8 @@ func (la *locatorAssertionsImpl) ToContainText(expected any, options ...LocatorA
 		ignoreCase = options[0].IgnoreCase
 	}
 
-	switch expected.(type) {
-	case []string, []*regexp.Regexp:
+	switch {
+	case isExpectedList(expected):
 		expectedText, err := toExpectedTextValues(convertToInterfaceList(expected), true, true, ignoreCase)
 		if err != nil {
 			return err
@@ -368,8 +367,8 @@ func (la *locatorAssertionsImpl) ToHaveClass(expected any, options ...LocatorAss
 	if len(options) == 1 {
 		timeout = options[0].Timeout
 	}
-	switch expected.(type) {
-	case []string, []*regexp.Regexp:
+	switch {
+	case isExpectedList(expected):
 		expectedText, err := toExpectedTextValues(convertToInterfaceList(expected), false, false, nil)
 		if err != nil {
 			return err
@@ -500,8 +499,8 @@ func (la *locatorAssertionsImpl) ToHaveText(expected any, options ...LocatorAsse
 		ignoreCase = options[0].IgnoreCase
 	}
 
-	switch expected.(type) {
-	case []string, []*regexp.Regexp:
+	switch {
+	case isExpectedList(expected):
 		expectedText, err := toExpectedTextValues(convertToInterfaceList(expected), false, true, ignoreCase)
 		if err != nil {
 			return err

--- a/tests/locator_assertions_test.go
+++ b/tests/locator_assertions_test.go
@@ -284,6 +284,31 @@ func TestLocatorAssertionsToHaveClass(t *testing.T) {
 	require.NoError(t, expect.Locator(locator2).Not().ToHaveClass("test1"))
 }
 
+// A list may mix strings and regexps, matching the documented "string or RegExp
+// or a list of those" (upstream Array<string|RegExp>).
+func TestLocatorAssertionsMixedStringRegexpList(t *testing.T) {
+	BeforeEach(t)
+
+	err := page.SetContent(`
+	<div class="test1">alpha</div>
+	<div class="test2">beta</div>
+	`)
+	require.NoError(t, err)
+
+	div := page.Locator("div")
+	require.NoError(t, div.Err())
+
+	require.NoError(t, expect.Locator(div).ToHaveText([]any{"alpha", regexp.MustCompile("bet.")}))
+	require.NoError(t, expect.Locator(div).ToContainText([]any{"alph", regexp.MustCompile("et")}))
+	require.NoError(t, expect.Locator(div).ToHaveClass([]any{"test1", regexp.MustCompile(`test\d`)}))
+
+	require.Error(t, expect.Locator(div).ToHaveText([]any{"alpha", regexp.MustCompile("gamma")}))
+	require.Error(t, expect.Locator(div).ToHaveClass([]any{"test1", regexp.MustCompile(`nope\d`)}))
+
+	// Elements that are neither string nor regexp are still rejected, per item.
+	require.Error(t, expect.Locator(div).ToHaveText([]any{"alpha", 42}))
+}
+
 func TestLocatorAssertionsToHaveCount(t *testing.T) {
 	BeforeEach(t)
 


### PR DESCRIPTION
Found while auditing the codebase for siblings of #627 — same root shape: a type the doc comment promises that the type switch doesn't list.

## Problem

`ToHaveText`, `ToContainText` and `ToHaveClass` document `expected` as:

> Expected string or RegExp or **a list of those**.

which is upstream's `Array<string|RegExp>` — explicitly mixable. But all three dispatched on the concrete slice type:

```go
switch expected.(type) {
case []string, []*regexp.Regexp:   // homogeneous only
```

so a mixed list fell through to the scalar branch and failed.

## Minimal reproducible

```go
page.SetContent(`<div class="test1">alpha</div><div class="test2">beta</div>`)
div := page.Locator("div")

expect.Locator(div).ToHaveText([]string{"alpha", "beta"})                       // ok
expect.Locator(div).ToHaveText([]*regexp.Regexp{/* ... */})                     // ok
expect.Locator(div).ToHaveText([]any{"alpha", regexp.MustCompile("bet.")})      // ✗
// → value must be a string or regexp
```

Same for `ToContainText` and `ToHaveClass`.

## How upstream does it

Upstream branches on **arity, not element type** — `Array.isArray(expected)` — and lets the serializer validate each element independently (`packages/playwright/src/matchers/matchers.ts:287`):

```ts
export function toHaveClass(
  this: ExpectMatcherStateInternal,
  locator: LocatorEx,
  expected: string | RegExp | (string | RegExp)[],
  ...
) {
  if (Array.isArray(expected)) {
    return toEqual.call(this, 'toHaveClass', locator, 'Locator', async (...) => {
      const expectedText = serializeExpectedTextValues(expected);   // per-element
      return await locator._expect('to.have.class.array', { expectedText, ... });
    }, expected, options);
  } else {
    ...
  }
}
```

Because element types never select the branch upstream, a mixed array is not a special case there — it just works. playwright-go encoded the element types into the branch, which is where the capability was lost.

## Fix

Mirror `Array.isArray` — dispatch on whether `expected` is a slice, and leave per-item validation to `toExpectedTextValues`, which already rejects non-string/non-regexp values:

```go
// isExpectedList reports whether the expected value is a list rather than a
// single item. It mirrors upstream's `Array.isArray(expected)` branch: the
// element types do not select the branch, they are validated per item by
// toExpectedTextValues.
func isExpectedList(expected any) bool {
	if expected == nil {
		return false
	}
	return reflect.ValueOf(expected).Kind() == reflect.Slice
}
```

```go
switch {
case isExpectedList(expected):
```

This is strictly wider than adding `[]any` to the case list, and matches upstream for any slice type. `convertToInterfaceList` already flattens arbitrary slices by reflection, so nothing downstream needed to change.

Homogeneous `[]string` / `[]*regexp.Regexp` behave exactly as before.

## Not changed: ToContainClass

Deliberately left alone. Upstream types it `string | string[]` and **explicitly throws** on RegExp (`matchers.ts:313`, `:320`):

```ts
if (expected.some(e => isRegExp(e)))
  throw new Error(`"expected" argument in toContainClass cannot contain RegExp values`);
```

playwright-go's existing `case []string:` / `case string:` switch with its `default: expected should be string or []string, but got %T` already enforces exactly that, with a good error message.

## Tests

`TestLocatorAssertionsMixedStringRegexpList` covers all three assertions with mixed lists — matching and non-matching — plus a list containing a non-text element to confirm per-item validation still rejects it.

Verified it fails on `main`:

```
=== RUN   TestLocatorAssertionsMixedStringRegexpList
    Error:  Received unexpected error:
            value must be a string or regexp
--- FAIL: TestLocatorAssertionsMixedStringRegexpList
```

and passes with the fix. Full `TestLocatorAssertions*` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hr35MBUfsUG9DnxhBgBcZW
