### PR TITLE
fix: report invalid GetBy*/HasText argument types instead of panicking

### DIFF
--- a/frame.go
+++ b/frame.go
@@ -881,7 +881,11 @@ func (f *frameImpl) GetByAltText(text any, options ...FrameGetByAltTextOptions) 
 			exact = true
 		}
 	}
-	return f.Locator(getByAltTextSelector(text, exact))
+	selector, err := getByAltTextSelector(text, exact)
+	if err != nil {
+		return newErrorLocator(f, err)
+	}
+	return f.Locator(selector)
 }
 
 func (f *frameImpl) GetByLabel(text any, options ...FrameGetByLabelOptions) Locator {
@@ -891,7 +895,11 @@ func (f *frameImpl) GetByLabel(text any, options ...FrameGetByLabelOptions) Loca
 			exact = true
 		}
 	}
-	return f.Locator(getByLabelSelector(text, exact))
+	selector, err := getByLabelSelector(text, exact)
+	if err != nil {
+		return newErrorLocator(f, err)
+	}
+	return f.Locator(selector)
 }
 
 func (f *frameImpl) GetByPlaceholder(text any, options ...FrameGetByPlaceholderOptions) Locator {
@@ -901,18 +909,34 @@ func (f *frameImpl) GetByPlaceholder(text any, options ...FrameGetByPlaceholderO
 			exact = true
 		}
 	}
-	return f.Locator(getByPlaceholderSelector(text, exact))
+	selector, err := getByPlaceholderSelector(text, exact)
+	if err != nil {
+		return newErrorLocator(f, err)
+	}
+	return f.Locator(selector)
 }
 
 func (f *frameImpl) GetByRole(role AriaRole, options ...FrameGetByRoleOptions) Locator {
 	if len(options) == 1 {
-		return f.Locator(getByRoleSelector(role, LocatorGetByRoleOptions(options[0])))
+		selector, err := getByRoleSelector(role, LocatorGetByRoleOptions(options[0]))
+		if err != nil {
+			return newErrorLocator(f, err)
+		}
+		return f.Locator(selector)
 	}
-	return f.Locator(getByRoleSelector(role))
+	selector, err := getByRoleSelector(role)
+	if err != nil {
+		return newErrorLocator(f, err)
+	}
+	return f.Locator(selector)
 }
 
 func (f *frameImpl) GetByTestId(testId any) Locator {
-	return f.Locator(getByTestIdSelector(getTestIdAttributeName(), testId))
+	selector, err := getByTestIdSelector(getTestIdAttributeName(), testId)
+	if err != nil {
+		return newErrorLocator(f, err)
+	}
+	return f.Locator(selector)
 }
 
 func (f *frameImpl) GetByText(text any, options ...FrameGetByTextOptions) Locator {
@@ -922,7 +946,11 @@ func (f *frameImpl) GetByText(text any, options ...FrameGetByTextOptions) Locato
 			exact = true
 		}
 	}
-	return f.Locator(getByTextSelector(text, exact))
+	selector, err := getByTextSelector(text, exact)
+	if err != nil {
+		return newErrorLocator(f, err)
+	}
+	return f.Locator(selector)
 }
 
 func (f *frameImpl) GetByTitle(text any, options ...FrameGetByTitleOptions) Locator {
@@ -932,7 +960,11 @@ func (f *frameImpl) GetByTitle(text any, options ...FrameGetByTitleOptions) Loca
 			exact = true
 		}
 	}
-	return f.Locator(getByTitleSelector(text, exact))
+	selector, err := getByTitleSelector(text, exact)
+	if err != nil {
+		return newErrorLocator(f, err)
+	}
+	return f.Locator(selector)
 }
 
 func (f *frameImpl) FrameLocator(selector string) FrameLocator {

--- a/frame_locator.go
+++ b/frame_locator.go
@@ -29,7 +29,11 @@ func (fl *frameLocatorImpl) GetByAltText(text any, options ...FrameLocatorGetByA
 			exact = true
 		}
 	}
-	return fl.Locator(getByAltTextSelector(text, exact))
+	selector, err := getByAltTextSelector(text, exact)
+	if err != nil {
+		return newErrorLocator(fl.frame, err)
+	}
+	return fl.Locator(selector)
 }
 
 func (fl *frameLocatorImpl) GetByLabel(text any, options ...FrameLocatorGetByLabelOptions) Locator {
@@ -39,7 +43,11 @@ func (fl *frameLocatorImpl) GetByLabel(text any, options ...FrameLocatorGetByLab
 			exact = true
 		}
 	}
-	return fl.Locator(getByLabelSelector(text, exact))
+	selector, err := getByLabelSelector(text, exact)
+	if err != nil {
+		return newErrorLocator(fl.frame, err)
+	}
+	return fl.Locator(selector)
 }
 
 func (fl *frameLocatorImpl) GetByPlaceholder(text any, options ...FrameLocatorGetByPlaceholderOptions) Locator {
@@ -49,18 +57,34 @@ func (fl *frameLocatorImpl) GetByPlaceholder(text any, options ...FrameLocatorGe
 			exact = true
 		}
 	}
-	return fl.Locator(getByPlaceholderSelector(text, exact))
+	selector, err := getByPlaceholderSelector(text, exact)
+	if err != nil {
+		return newErrorLocator(fl.frame, err)
+	}
+	return fl.Locator(selector)
 }
 
 func (fl *frameLocatorImpl) GetByRole(role AriaRole, options ...FrameLocatorGetByRoleOptions) Locator {
 	if len(options) == 1 {
-		return fl.Locator(getByRoleSelector(role, LocatorGetByRoleOptions(options[0])))
+		selector, err := getByRoleSelector(role, LocatorGetByRoleOptions(options[0]))
+		if err != nil {
+			return newErrorLocator(fl.frame, err)
+		}
+		return fl.Locator(selector)
 	}
-	return fl.Locator(getByRoleSelector(role))
+	selector, err := getByRoleSelector(role)
+	if err != nil {
+		return newErrorLocator(fl.frame, err)
+	}
+	return fl.Locator(selector)
 }
 
 func (fl *frameLocatorImpl) GetByTestId(testId any) Locator {
-	return fl.Locator(getByTestIdSelector(getTestIdAttributeName(), testId))
+	selector, err := getByTestIdSelector(getTestIdAttributeName(), testId)
+	if err != nil {
+		return newErrorLocator(fl.frame, err)
+	}
+	return fl.Locator(selector)
 }
 
 func (fl *frameLocatorImpl) GetByText(text any, options ...FrameLocatorGetByTextOptions) Locator {
@@ -70,7 +94,11 @@ func (fl *frameLocatorImpl) GetByText(text any, options ...FrameLocatorGetByText
 			exact = true
 		}
 	}
-	return fl.Locator(getByTextSelector(text, exact))
+	selector, err := getByTextSelector(text, exact)
+	if err != nil {
+		return newErrorLocator(fl.frame, err)
+	}
+	return fl.Locator(selector)
 }
 
 func (fl *frameLocatorImpl) GetByTitle(text any, options ...FrameLocatorGetByTitleOptions) Locator {
@@ -80,7 +108,11 @@ func (fl *frameLocatorImpl) GetByTitle(text any, options ...FrameLocatorGetByTit
 			exact = true
 		}
 	}
-	return fl.Locator(getByTitleSelector(text, exact))
+	selector, err := getByTitleSelector(text, exact)
+	if err != nil {
+		return newErrorLocator(fl.frame, err)
+	}
+	return fl.Locator(selector)
 }
 
 func (fl *frameLocatorImpl) Last() FrameLocator {

--- a/locator.go
+++ b/locator.go
@@ -28,10 +28,20 @@ func newLocator(frame *frameImpl, selector string, options ...LocatorOptions) *l
 	}
 	locator := &locatorImpl{frame: frame, selector: selector, options: option, err: nil}
 	if option.HasText != nil {
-		selector += fmt.Sprintf(` >> internal:has-text=%s`, escapeForTextSelector(option.HasText, false))
+		escaped, err := escapeForTextSelector(option.HasText, false)
+		if err != nil {
+			locator.err = errors.Join(locator.err, fmt.Errorf("HasText: %w", err))
+		} else {
+			selector += fmt.Sprintf(` >> internal:has-text=%s`, escaped)
+		}
 	}
 	if option.HasNotText != nil {
-		selector += fmt.Sprintf(` >> internal:has-not-text=%s`, escapeForTextSelector(option.HasNotText, false))
+		escaped, err := escapeForTextSelector(option.HasNotText, false)
+		if err != nil {
+			locator.err = errors.Join(locator.err, fmt.Errorf("HasNotText: %w", err))
+		} else {
+			selector += fmt.Sprintf(` >> internal:has-not-text=%s`, escaped)
+		}
 	}
 	if option.Has != nil {
 		has := option.Has.(*locatorImpl)
@@ -56,6 +66,16 @@ func newLocator(frame *frameImpl, selector string, options ...LocatorOptions) *l
 	locator.selector = selector
 
 	return locator
+}
+
+// newErrorLocator returns a Locator that only carries err. The GetBy* methods
+// return a Locator with no error slot of their own, so an unsupported argument
+// type is reported the same way an invalid selector parameter already is: the
+// error surfaces via Err() and from every action on the locator, rather than
+// panicking. Upstream needs no equivalent because its `string | RegExp`
+// parameter types reject these arguments at compile time.
+func newErrorLocator(frame *frameImpl, err error) *locatorImpl {
+	return &locatorImpl{frame: frame, options: &LocatorOptions{}, err: err}
 }
 
 func (l *locatorImpl) equals(locator Locator) bool {
@@ -477,7 +497,11 @@ func (l *locatorImpl) GetByAltText(text any, options ...LocatorGetByAltTextOptio
 			exact = true
 		}
 	}
-	return l.Locator(getByAltTextSelector(text, exact))
+	selector, err := getByAltTextSelector(text, exact)
+	if err != nil {
+		return l.withError(err)
+	}
+	return l.Locator(selector)
 }
 
 func (l *locatorImpl) GetByLabel(text any, options ...LocatorGetByLabelOptions) Locator {
@@ -487,7 +511,11 @@ func (l *locatorImpl) GetByLabel(text any, options ...LocatorGetByLabelOptions) 
 			exact = true
 		}
 	}
-	return l.Locator(getByLabelSelector(text, exact))
+	selector, err := getByLabelSelector(text, exact)
+	if err != nil {
+		return l.withError(err)
+	}
+	return l.Locator(selector)
 }
 
 func (l *locatorImpl) GetByPlaceholder(text any, options ...LocatorGetByPlaceholderOptions) Locator {
@@ -497,15 +525,27 @@ func (l *locatorImpl) GetByPlaceholder(text any, options ...LocatorGetByPlacehol
 			exact = true
 		}
 	}
-	return l.Locator(getByPlaceholderSelector(text, exact))
+	selector, err := getByPlaceholderSelector(text, exact)
+	if err != nil {
+		return l.withError(err)
+	}
+	return l.Locator(selector)
 }
 
 func (l *locatorImpl) GetByRole(role AriaRole, options ...LocatorGetByRoleOptions) Locator {
-	return l.Locator(getByRoleSelector(role, options...))
+	selector, err := getByRoleSelector(role, options...)
+	if err != nil {
+		return l.withError(err)
+	}
+	return l.Locator(selector)
 }
 
 func (l *locatorImpl) GetByTestId(testId any) Locator {
-	return l.Locator(getByTestIdSelector(getTestIdAttributeName(), testId))
+	selector, err := getByTestIdSelector(getTestIdAttributeName(), testId)
+	if err != nil {
+		return l.withError(err)
+	}
+	return l.Locator(selector)
 }
 
 func (l *locatorImpl) GetByText(text any, options ...LocatorGetByTextOptions) Locator {
@@ -515,7 +555,11 @@ func (l *locatorImpl) GetByText(text any, options ...LocatorGetByTextOptions) Lo
 			exact = true
 		}
 	}
-	return l.Locator(getByTextSelector(text, exact))
+	selector, err := getByTextSelector(text, exact)
+	if err != nil {
+		return l.withError(err)
+	}
+	return l.Locator(selector)
 }
 
 func (l *locatorImpl) GetByTitle(text any, options ...LocatorGetByTitleOptions) Locator {
@@ -525,7 +569,11 @@ func (l *locatorImpl) GetByTitle(text any, options ...LocatorGetByTitleOptions) 
 			exact = true
 		}
 	}
-	return l.Locator(getByTitleSelector(text, exact))
+	selector, err := getByTitleSelector(text, exact)
+	if err != nil {
+		return l.withError(err)
+	}
+	return l.Locator(selector)
 }
 
 func (l *locatorImpl) HideHighlight() error {

--- a/locator_helpers.go
+++ b/locator_helpers.go
@@ -19,28 +19,39 @@ func convertRegexp(reg *regexp.Regexp) (pattern, flags string) {
 	return
 }
 
-func escapeForAttributeSelector(text any, exact bool) string {
+// errInvalidTextArgument reports an argument that is neither a string nor a
+// regexp. Upstream relies on its `string | RegExp` types to rule this out at
+// compile time; the Go signatures are `any`, so it has to be checked here.
+func errInvalidTextArgument(text any) error {
+	return fmt.Errorf("expected string or *regexp.Regexp, but got %T", text)
+}
+
+func escapeForAttributeSelector(text any, exact bool) (string, error) {
 	switch text := text.(type) {
 	case *regexp.Regexp:
-		return escapeRegexForSelector(text)
-	default:
+		return escapeRegexForSelector(text), nil
+	case string:
 		suffix := "i"
 		if exact {
 			suffix = "s"
 		}
-		return fmt.Sprintf(`"%s"%s`, strings.ReplaceAll(strings.ReplaceAll(text.(string), `\`, `\\`), `"`, `\"`), suffix)
+		return fmt.Sprintf(`"%s"%s`, strings.ReplaceAll(strings.ReplaceAll(text, `\`, `\\`), `"`, `\"`), suffix), nil
+	default:
+		return "", errInvalidTextArgument(text)
 	}
 }
 
-func escapeForTextSelector(text any, exact bool) string {
+func escapeForTextSelector(text any, exact bool) (string, error) {
 	switch text := text.(type) {
 	case *regexp.Regexp:
-		return escapeRegexForSelector(text)
-	default:
+		return escapeRegexForSelector(text), nil
+	case string:
 		if exact {
-			return fmt.Sprintf(`%ss`, escapeText(text.(string)))
+			return fmt.Sprintf(`%ss`, escapeText(text)), nil
 		}
-		return fmt.Sprintf(`%si`, escapeText(text.(string)))
+		return fmt.Sprintf(`%si`, escapeText(text)), nil
+	default:
+		return "", errInvalidTextArgument(text)
 	}
 }
 
@@ -101,23 +112,31 @@ func escapeText(s string) string {
 	return strings.TrimSpace(builder.String())
 }
 
-func getByAltTextSelector(text any, exact bool) string {
+func getByAltTextSelector(text any, exact bool) (string, error) {
 	return getByAttributeTextSelector("alt", text, exact)
 }
 
-func getByAttributeTextSelector(attrName string, text any, exact bool) string {
-	return fmt.Sprintf(`internal:attr=[%s=%s]`, attrName, escapeForAttributeSelector(text, exact))
+func getByAttributeTextSelector(attrName string, text any, exact bool) (string, error) {
+	escaped, err := escapeForAttributeSelector(text, exact)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(`internal:attr=[%s=%s]`, attrName, escaped), nil
 }
 
-func getByLabelSelector(text any, exact bool) string {
-	return fmt.Sprintf(`internal:label=%s`, escapeForTextSelector(text, exact))
+func getByLabelSelector(text any, exact bool) (string, error) {
+	escaped, err := escapeForTextSelector(text, exact)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(`internal:label=%s`, escaped), nil
 }
 
-func getByPlaceholderSelector(text any, exact bool) string {
+func getByPlaceholderSelector(text any, exact bool) (string, error) {
 	return getByAttributeTextSelector("placeholder", text, exact)
 }
 
-func getByRoleSelector(role AriaRole, options ...LocatorGetByRoleOptions) string {
+func getByRoleSelector(role AriaRole, options ...LocatorGetByRoleOptions) (string, error) {
 	// Keep the property ordering stable and identical to upstream, since the
 	// produced selector string must be deterministic.
 	props := make([][2]string, 0)
@@ -145,10 +164,18 @@ func getByRoleSelector(role AriaRole, options ...LocatorGetByRoleOptions) string
 			props = append(props, [2]string{"level", fmt.Sprintf("%d", *options[0].Level)})
 		}
 		if options[0].Name != nil {
-			props = append(props, [2]string{"name", escapeForAttributeSelector(options[0].Name, exact)})
+			escaped, err := escapeForAttributeSelector(options[0].Name, exact)
+			if err != nil {
+				return "", err
+			}
+			props = append(props, [2]string{"name", escaped})
 		}
 		if options[0].Description != nil {
-			props = append(props, [2]string{"description", escapeForAttributeSelector(options[0].Description, exact)})
+			escaped, err := escapeForAttributeSelector(options[0].Description, exact)
+			if err != nil {
+				return "", err
+			}
+			props = append(props, [2]string{"description", escaped})
 		}
 		if options[0].Pressed != nil {
 			props = append(props, [2]string{"pressed", fmt.Sprintf("%t", *options[0].Pressed)})
@@ -158,15 +185,23 @@ func getByRoleSelector(role AriaRole, options ...LocatorGetByRoleOptions) string
 	for _, p := range props {
 		propsStr.WriteString("[" + p[0] + "=" + p[1] + "]")
 	}
-	return fmt.Sprintf("internal:role=%s%s", role, propsStr.String())
+	return fmt.Sprintf("internal:role=%s%s", role, propsStr.String()), nil
 }
 
-func getByTextSelector(text any, exact bool) string {
-	return fmt.Sprintf(`internal:text=%s`, escapeForTextSelector(text, exact))
+func getByTextSelector(text any, exact bool) (string, error) {
+	escaped, err := escapeForTextSelector(text, exact)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(`internal:text=%s`, escaped), nil
 }
 
-func getByTestIdSelector(testIdAttributeName string, testId any) string {
-	return fmt.Sprintf(`internal:testid=[%s=%s]`, encodeTestIdAttributeName(testIdAttributeName), escapeForAttributeSelector(testId, true))
+func getByTestIdSelector(testIdAttributeName string, testId any) (string, error) {
+	escaped, err := escapeForAttributeSelector(testId, true)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(`internal:testid=[%s=%s]`, encodeTestIdAttributeName(testIdAttributeName), escaped), nil
 }
 
 // encodeTestIdAttributeName JSON-quotes the attribute name when it contains a
@@ -183,7 +218,7 @@ func encodeTestIdAttributeName(testIdAttributeName string) string {
 	return testIdAttributeName
 }
 
-func getByTitleSelector(text any, exact bool) string {
+func getByTitleSelector(text any, exact bool) (string, error) {
 	return getByAttributeTextSelector("title", text, exact)
 }
 

--- a/page.go
+++ b/page.go
@@ -1386,7 +1386,11 @@ func (p *pageImpl) GetByAltText(text any, options ...PageGetByAltTextOptions) Lo
 			exact = true
 		}
 	}
-	return p.Locator(getByAltTextSelector(text, exact))
+	selector, err := getByAltTextSelector(text, exact)
+	if err != nil {
+		return newErrorLocator(p.mainFrame.(*frameImpl), err)
+	}
+	return p.Locator(selector)
 }
 
 func (p *pageImpl) GetByLabel(text any, options ...PageGetByLabelOptions) Locator {
@@ -1396,7 +1400,11 @@ func (p *pageImpl) GetByLabel(text any, options ...PageGetByLabelOptions) Locato
 			exact = true
 		}
 	}
-	return p.Locator(getByLabelSelector(text, exact))
+	selector, err := getByLabelSelector(text, exact)
+	if err != nil {
+		return newErrorLocator(p.mainFrame.(*frameImpl), err)
+	}
+	return p.Locator(selector)
 }
 
 func (p *pageImpl) GetByPlaceholder(text any, options ...PageGetByPlaceholderOptions) Locator {
@@ -1406,18 +1414,34 @@ func (p *pageImpl) GetByPlaceholder(text any, options ...PageGetByPlaceholderOpt
 			exact = true
 		}
 	}
-	return p.Locator(getByPlaceholderSelector(text, exact))
+	selector, err := getByPlaceholderSelector(text, exact)
+	if err != nil {
+		return newErrorLocator(p.mainFrame.(*frameImpl), err)
+	}
+	return p.Locator(selector)
 }
 
 func (p *pageImpl) GetByRole(role AriaRole, options ...PageGetByRoleOptions) Locator {
 	if len(options) == 1 {
-		return p.Locator(getByRoleSelector(role, LocatorGetByRoleOptions(options[0])))
+		selector, err := getByRoleSelector(role, LocatorGetByRoleOptions(options[0]))
+		if err != nil {
+			return newErrorLocator(p.mainFrame.(*frameImpl), err)
+		}
+		return p.Locator(selector)
 	}
-	return p.Locator(getByRoleSelector(role))
+	selector, err := getByRoleSelector(role)
+	if err != nil {
+		return newErrorLocator(p.mainFrame.(*frameImpl), err)
+	}
+	return p.Locator(selector)
 }
 
 func (p *pageImpl) GetByTestId(testId any) Locator {
-	return p.Locator(getByTestIdSelector(getTestIdAttributeName(), testId))
+	selector, err := getByTestIdSelector(getTestIdAttributeName(), testId)
+	if err != nil {
+		return newErrorLocator(p.mainFrame.(*frameImpl), err)
+	}
+	return p.Locator(selector)
 }
 
 func (p *pageImpl) GetByText(text any, options ...PageGetByTextOptions) Locator {
@@ -1427,7 +1451,11 @@ func (p *pageImpl) GetByText(text any, options ...PageGetByTextOptions) Locator 
 			exact = true
 		}
 	}
-	return p.Locator(getByTextSelector(text, exact))
+	selector, err := getByTextSelector(text, exact)
+	if err != nil {
+		return newErrorLocator(p.mainFrame.(*frameImpl), err)
+	}
+	return p.Locator(selector)
 }
 
 func (p *pageImpl) GetByTitle(text any, options ...PageGetByTitleOptions) Locator {
@@ -1437,7 +1465,11 @@ func (p *pageImpl) GetByTitle(text any, options ...PageGetByTitleOptions) Locato
 			exact = true
 		}
 	}
-	return p.Locator(getByTitleSelector(text, exact))
+	selector, err := getByTitleSelector(text, exact)
+	if err != nil {
+		return newErrorLocator(p.mainFrame.(*frameImpl), err)
+	}
+	return p.Locator(selector)
 }
 
 func (p *pageImpl) FrameLocator(selector string) FrameLocator {

--- a/tests/locator_get_by_test.go
+++ b/tests/locator_get_by_test.go
@@ -166,3 +166,61 @@ func TestGetByRole(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, count)
 }
+
+// The GetBy* text parameters are `any` because Go has no string|RegExp union,
+// so an unsupported type has to surface through Locator.Err() rather than
+// panicking on an unchecked type assertion.
+func TestGetByRejectsInvalidArgumentType(t *testing.T) {
+	BeforeEach(t)
+
+	require.NoError(t, page.SetContent(`<div><button title="Hello">Hello</button></div>`))
+
+	const wantErr = "expected string or *regexp.Regexp, but got int"
+
+	frame := page.MainFrame()
+	locator := page.Locator("div")
+	frameLocator := page.FrameLocator(":scope")
+
+	for name, got := range map[string]playwright.Locator{
+		"page.GetByText":          page.GetByText(42),
+		"page.GetByLabel":         page.GetByLabel(42),
+		"page.GetByPlaceholder":   page.GetByPlaceholder(42),
+		"page.GetByAltText":       page.GetByAltText(42),
+		"page.GetByTitle":         page.GetByTitle(42),
+		"page.GetByTestId":        page.GetByTestId(42),
+		"frame.GetByText":         frame.GetByText(42),
+		"frame.GetByTestId":       frame.GetByTestId(42),
+		"locator.GetByText":       locator.GetByText(42),
+		"locator.GetByTestId":     locator.GetByTestId(42),
+		"frameLocator.GetByText":  frameLocator.GetByText(42),
+		"frameLocator.GetByTitle": frameLocator.GetByTitle(42),
+	} {
+		require.ErrorContains(t, got.Err(), wantErr, name)
+		// The error must also come back from actions on the locator.
+		_, err := got.Count()
+		require.ErrorContains(t, err, wantErr, name)
+	}
+
+	// GetByRole carries the same hazard through its Name/Description options.
+	require.ErrorContains(t, page.GetByRole("button", playwright.PageGetByRoleOptions{
+		Name: 42,
+	}).Err(), wantErr)
+	require.ErrorContains(t, page.GetByRole("button", playwright.PageGetByRoleOptions{
+		Description: 42,
+	}).Err(), wantErr)
+
+	// So do the HasText/HasNotText locator options.
+	require.ErrorContains(t, page.Locator("div", playwright.PageLocatorOptions{
+		HasText: 42,
+	}).Err(), "HasText: "+wantErr)
+	require.ErrorContains(t, page.Locator("div", playwright.PageLocatorOptions{
+		HasNotText: 42,
+	}).Err(), "HasNotText: "+wantErr)
+
+	// Valid arguments are unaffected.
+	require.NoError(t, page.GetByText("Hello").Err())
+	require.NoError(t, page.GetByTitle(regexp.MustCompile("Hel")).Err())
+	count, err := page.GetByText("Hello").Count()
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+}


### PR DESCRIPTION
Third and last finding from the audit for siblings of #627. Same family — an `any` parameter resolved at runtime — this time an unchecked type assertion.

## Problem

The `GetBy*` text parameters are `any` because Go has no `string | RegExp` union. Both selector escape helpers assumed anything that was not a regexp had to be a string (`locator_helpers.go:35`):

```go
func escapeForTextSelector(text any, exact bool) string {
	switch text := text.(type) {
	case *regexp.Regexp:
		return escapeRegexForSelector(text)
	default:
		if exact {
			return fmt.Sprintf(`%ss`, escapeText(text.(string)))   // ← unchecked
		}
		return fmt.Sprintf(`%si`, escapeText(text.(string)))
	}
}
```

## Minimal reproducible

```go
page.GetByText(42)
// panic: interface conversion: interface {} is int, not string
```

The blast radius is wider than it first looks — everything funnels through these two helpers:

- `GetByText`, `GetByLabel`, `GetByPlaceholder`, `GetByAltText`, `GetByTitle`, `GetByTestId` — on **Page, Frame, Locator and FrameLocator** (24 methods)
- `GetByRole`'s `Name` and `Description` options
- the `HasText` / `HasNotText` locator options, via `newLocator` (`locator.go:31`)

## How upstream does it

Upstream doesn't check, because it doesn't have to. Every one of these parameters is typed `string | RegExp`, so the compiler rejects `42` at the call site, and the helper can treat "not a string" as "must be a regexp" (`packages/isomorphic/stringUtils.ts:110`):

```ts
export function escapeForTextSelector(text: string | RegExp, exact: boolean): string {
  if (typeof text !== 'string')
    return escapeRegexForSelector(text);
  return `${JSON.stringify(text)}${exact ? 's' : 'i'}`;
}
```

playwright-go ported that inverted shape faithfully — but without the union type that makes it safe. This is the one finding of the three where upstream has no runtime behavior to copy: the fix has to come from Go's own conventions instead.

## Fix

Both escape helpers and the `getBy*Selector` helpers above them now return an error, and each `GetBy*` returns a `Locator` carrying it:

```go
selector, err := getByTextSelector(text, exact)
if err != nil {
    return newErrorLocator(f, err)
}
return f.Locator(selector)
```

This is the package's existing convention in two respects:

1. **`Locator.Err()` is already how deferred locator errors surface.** `Locator(selectorOrLocator)` already returns `l.withError(fmt.Errorf("invalid locator parameter: %v", ...))` for a bad parameter — same situation, same reporting. `locatorImpl` uses `l.withError`; the other three receivers use a new `newErrorLocator(frame, err)`.
2. **Naming the offending type in the error** is what `Fetch`, `NewCDPSession`, `Clock.parseTime`/`parseTicks`, `convertInputFiles` and `ToContainClass` already do. `newURLMatcher`'s bare panic is the outlier, not the norm.

```
expected string or *regexp.Regexp, but got int
HasText: expected string or *regexp.Regexp, but got int
```

`newLocator` folds `HasText`/`HasNotText` failures into the locator's existing `err` field, right next to the `ErrLocatorNotSameFrame` handling that was already there.

## Tests

`TestGetByRejectsInvalidArgumentType` covers all four receivers across the GetBy* family, `GetByRole`'s `Name`/`Description`, and `HasText`/`HasNotText`. It asserts the error is reachable **both** from `Err()` and from an action on the locator (`Count()`), then confirms valid string and regexp arguments still work.

Verified against `main`:

```
--- FAIL: TestGetByRejectsInvalidArgumentType
panic: interface conversion: interface {} is int, not string
```

Full `go test ./...` is green with the fix (unit suite + the whole `tests` package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hr35MBUfsUG9DnxhBgBcZW
