### PR TITLE
docs: fix the coverage badge and link the CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![PkgGoDev](https://pkg.go.dev/badge/github.com/mxschmitt/playwright-go)](https://pkg.go.dev/github.com/mxschmitt/playwright-go)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](http://opensource.org/licenses/MIT)
-![Build Status](https://github.com/mxschmitt/playwright-go/workflows/Go/badge.svg)
+[![Go](https://github.com/mxschmitt/playwright-go/actions/workflows/build.yml/badge.svg)](https://github.com/mxschmitt/playwright-go/actions/workflows/build.yml)
 [![Tests](https://img.shields.io/endpoint?url=https%3A%2F%2Fflakiness.io%2Fapi%2Fbadge%3Finput%3D%257B%2522badgeToken%2522%253A%2522badge-6g4pNCL3d8qZbDdJEqFhSI%2522%257D)](https://flakiness.io/playwright-community/playwright-go)
-[![Coverage Status](https://img.shields.io/coverallsCoverage/github/mxschmitt/playwright-go?branch=main)](https://coveralls.io/github/mxschmitt/playwright-go?branch=main)
+[![Coverage Status](https://coveralls.io/repos/github/mxschmitt/playwright-go/badge.svg?branch=main)](https://coveralls.io/github/mxschmitt/playwright-go?branch=main)
 [![Join Discord](https://img.shields.io/badge/join-discord-informational)](https://aka.ms/playwright/discord)
 <!-- GEN:chromium-version-badge -->[![Chromium version](https://img.shields.io/badge/chromium-151.0.7922.34-blue.svg?logo=google-chrome)](https://www.chromium.org/Home)<!-- GEN:stop --> <!-- GEN:firefox-version-badge -->[![Firefox version](https://img.shields.io/badge/firefox-153.0-blue.svg?logo=mozilla-firefox)](https://www.mozilla.org/en-US/firefox/new/)<!-- GEN:stop --> <!-- GEN:webkit-version-badge -->[![WebKit version](https://img.shields.io/badge/webkit-26.5-blue.svg?logo=safari)](https://webkit.org/)<!-- GEN:stop -->
 


### PR DESCRIPTION
Two badge fixes in the README header.

**Coverage badge** — #620 switched it from coveralls' own badge URL to the shields.io `coverallsCoverage` endpoint. That endpoint now renders `coverage: invalid`, because shields reads `https://coveralls.io/repos/github/mxschmitt/playwright-go.json`, and that API is behind a Cloudflare "Just a moment..." interstitial:

```
$ curl -s "https://img.shields.io/coverallsCoverage/github/mxschmitt/playwright-go?branch=main"
<svg ... aria-label="coverage: invalid">

$ curl -s "https://coveralls.io/repos/github/mxschmitt/playwright-go.json?branch=main"
<!DOCTYPE html><html lang="en-US"><head><title>Just a moment...</title>
```

Coveralls' own badge URL does work — it 302s to S3 and lands on a real SVG:

```
$ curl -sL -o /dev/null -w "%{http_code} %{content_type} %{url_effective}\n" \
    "https://coveralls.io/repos/github/mxschmitt/playwright-go/badge.svg?branch=main"
200 image/svg+xml https://s3.amazonaws.com/assets.coveralls.io/badges/coveralls_80.svg
```

So this reverts that badge back to the coveralls URL.

**CI badge** — it was the only badge in the header that wasn't a link. Switched to the current `/actions/workflows/build.yml/badge.svg` form (the legacy `/workflows/Go/badge.svg` path is deprecated) and linked it to the workflow's runs page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fe1uKA17jDoXYiQk8hmnPa
